### PR TITLE
Support Python 3.4

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -198,6 +198,13 @@ approach for specifying the IMAP password. Either this option or
 <dt>-s --use-ssl</dt>
 <dd>Use SSL to connect to the IMAP server (default: no).</dd>
 
+<dt>--insecure</dt>
+<dd>Do no certificate validation when connecting to an SSL IMAP server (default:
+no).  This means the certificate subject names will be ignored, as will any
+certificate authorities.  Your connection will not be protected from active
+attackers.
+</dd>
+
 </dl>
 
 <h2>Configuration</h2>

--- a/mailprocessing/cmd/imap.py
+++ b/mailprocessing/cmd/imap.py
@@ -193,6 +193,11 @@ def main():
         action="store_true",
         default=False,
         help="Use SSL to connect to IMAP server.")
+    parser.add_option(
+        "--insecure",
+        action="store_true",
+        default=False,
+        help="Skip SSL certificate validation when connecting to IMAP server (unsafe).")
 
     (options, _) = parser.parse_args(sys.argv[1:])
 
@@ -209,6 +214,10 @@ def main():
 
     if options.password and options.password_command:
         print("Please specify only one of --password or --password-command.", file=sys.stderr)
+        bad_options = True
+
+    if options.insecure and options.certfile:
+        print("Please specify only one of --insecure or --certfile.", file=sys.stderr)
         bad_options = True
 
     if bad_options:
@@ -258,7 +267,7 @@ def main():
 
     for opt in ("auto_reload_rcfile", "certfile", "dry_run", "folders",
                 "folder_prefix", "folder_separator", "host", "interval",
-                "port", "user", "use_ssl", "verbosity"):
+                "port", "user", "use_ssl", "insecure", "verbosity"):
         processor_kwargs[opt] = options.__dict__[opt]
 
     if options.cache_headers:

--- a/mailprocessing/processor/imap.py
+++ b/mailprocessing/processor/imap.py
@@ -65,6 +65,8 @@ class ImapProcessor(MailProcessor):
             if not kwargs['port']:
                 port = 993
             ssl_context = ssl.SSLContext(getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23))
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.check_hostname = True
             if kwargs['certfile']:
                 ssl_context.load_cert_chain(kwargs['certfile'])
             else:

--- a/mailprocessing/processor/imap.py
+++ b/mailprocessing/processor/imap.py
@@ -65,8 +65,11 @@ class ImapProcessor(MailProcessor):
             if not kwargs['port']:
                 port = 993
             ssl_context = ssl.SSLContext(getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23))
-            ssl_context.verify_mode = ssl.CERT_REQUIRED
-            ssl_context.check_hostname = True
+            if kwargs['insecure']:
+                ssl_context.verify_mode = ssl.CERT_NONE
+            else:
+                ssl_context.verify_mode = ssl.CERT_REQUIRED
+                ssl_context.check_hostname = True
             if kwargs['certfile']:
                 ssl_context.load_cert_chain(kwargs['certfile'])
             else:

--- a/mailprocessing/processor/imap.py
+++ b/mailprocessing/processor/imap.py
@@ -64,7 +64,7 @@ class ImapProcessor(MailProcessor):
         if kwargs['use_ssl']:
             if not kwargs['port']:
                 port = 993
-            ssl_context = ssl.SSLContext()
+            ssl_context = ssl.SSLContext(getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23))
             if kwargs['certfile']:
                 ssl_context.load_cert_chain(kwargs['certfile'])
             else:


### PR DESCRIPTION
OpenSUSE Leap 42.3 still ships with Python 3.4.6. That still requires the protocol specification in the `SSLContext()` constructor.

Also, the code was never checking certificate validity (that the name in the cert matches the destination, and that a cert was actually given).

I'm afraid that I haven't been able to run the test suite yet; it isn't clear how to run that. Do I need to install the package to run the test suite?

I also notice that `run-pylint` refers to the old module name, so it doesn't appear to have been run in a while.

Thanks!