### PR TITLE
flake8, fix for sep='/'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ upload: all
 clean:
 	rm -rf maildirproc*-$(VERSION) build dist MANIFEST
 	rm -rf *.gz
-	find -name '*~' | xargs rm -f
+	find . -name '*~' | xargs rm -f
 
 .PHONY: all clean docs

--- a/mailprocessing/cmd/imap.py
+++ b/mailprocessing/cmd/imap.py
@@ -37,6 +37,7 @@ from mailprocessing.util import iso_8601_now
 from mailprocessing.util import write_pidfile
 from mailprocessing.version import PKG_VERSION
 
+
 def main():
     imapproc_directory = "~/.mailprocessing"
     default_rcfile_location = os.path.join(imapproc_directory, "imap.rc")
@@ -174,7 +175,7 @@ def main():
         "--port",
         type="int",
         help="IMAP port to use. Defaults to 143 if --use-ssl is not specified "
-              "and 993 if it is.")
+             "and 993 if it is.")
     parser.add_option(
         "--folder-prefix",
         type="string",
@@ -226,10 +227,10 @@ def main():
 
     for opt in ("host", "user"):
         if not options.__dict__[opt]:
-           print("Please specify --%s option." % opt, file=sys.stderr)
-           bad_options = True
+            print("Please specify --%s option." % opt, file=sys.stderr)
+            bad_options = True
 
-    if not ( options.password or options.password_command ):
+    if not (options.password or options.password_command):
         print("Please specify either --password or --password-command.", file=sys.stderr)
         bad_options = True
 
@@ -259,7 +260,7 @@ def main():
             sys.stderr.buffer.write(e.output)
             sys.exit(1)
         except Exception as e:
-            print ("Could not execute command %s: %s" % (options.password_command, e))
+            print("Could not execute command %s: %s" % (options.password_command, e))
             sys.exit(1)
         processor_kwargs['password'] = p
 

--- a/mailprocessing/cmd/maildir.py
+++ b/mailprocessing/cmd/maildir.py
@@ -19,7 +19,7 @@
 
 """maildirproc -- maildir processor
 
-http://mailprocessing.github.io/mailprocessing 
+http://mailprocessing.github.io/mailprocessing
 
 maildirproc is a small program that processes one or several existing
 mail boxes in the maildir format. It is primarily focused on mail
@@ -40,6 +40,7 @@ from mailprocessing.processor.maildir import MaildirProcessor
 from mailprocessing.util import iso_8601_now
 
 from mailprocessing.version import PKG_VERSION
+
 
 def main():
     maildirproc_directory = "~/.mailprocessing"

--- a/mailprocessing/mail/base.py
+++ b/mailprocessing/mail/base.py
@@ -17,10 +17,9 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301, USA.
 
-import sys
-
 from mailprocessing.mail.target import MailTarget
 from mailprocessing.mail.header import MailHeader
+
 
 class MailBase(object):
     """
@@ -79,8 +78,7 @@ class MailBase(object):
             "... Mail is not on mailing list {0}".format(list_name))
         return False
 
-
-    ### Methods to implement ###
+    # Methods to implement ###
 
     def copy(self, folder, create=False):
         """
@@ -176,6 +174,8 @@ class MailBase(object):
         metadata (typically a selection of headers) to the log file.
         """
 
+        message = ("You need to implement a log_processing() method in your "
+                   "MailBase subclass.")
         raise NotImplementedError(message)
 
     def is_seen(self):

--- a/mailprocessing/mail/dryrun.py
+++ b/mailprocessing/mail/dryrun.py
@@ -17,16 +17,16 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301, USA.
 
-from mailprocessing.mail.base import MailBase
 from mailprocessing.mail.imap import ImapMail
 from mailprocessing.mail.maildir import MaildirMail
+
 
 class DryRunImap(ImapMail):
     def __init__(self, *args, **kwargs):
         super(DryRunImap, self).__init__(*args, **kwargs)
 
     def copy(self, maildir, **kwargs):
-        maildir = self.processor.list_path(maildir, 
+        maildir = self.processor.list_path(maildir,
                                            sep=self.processor.separator)
         self._processor.log("==> Copying to {0}".format(maildir))
 
@@ -40,14 +40,14 @@ class DryRunImap(ImapMail):
         self._forward(False, addresses, env_sender)
 
     def move(self, maildir, **kwargs):
-        maildir = self.processor.list_path(maildir, 
+        maildir = self.processor.list_path(maildir,
                                            sep=self.processor.separator)
         self._processor.log("==> Moving to {0}".format(maildir))
 
     # ----------------------------------------------------------------
 
     def _forward(self, delete, addresses, env_sender):
-        if isinstance(addresses, basestring):
+        if isinstance(addresses, str):
             addresses = [addresses]
         else:
             addresses = list(addresses)
@@ -68,7 +68,7 @@ class DryRunMaildir(MaildirMail):
         super(DryRunMaildir, self).__init__(*args, **kwargs)
 
     def copy(self, maildir, **kwargs):
-        maildir = self.processor.list_path(maildir, 
+        maildir = self.processor.list_path(maildir,
                                            sep=self.processor.separator)
         self._processor.log("==> Copying to {0}".format(maildir))
 
@@ -82,14 +82,14 @@ class DryRunMaildir(MaildirMail):
         self._forward(False, addresses, env_sender)
 
     def move(self, maildir, **kwargs):
-        maildir = self.processor.list_path(maildir, 
+        maildir = self.processor.list_path(maildir,
                                            sep=self.processor.separator)
         self._processor.log("==> Moving to {0}".format(maildir))
 
     # ----------------------------------------------------------------
 
     def _forward(self, delete, addresses, env_sender):
-        if isinstance(addresses, basestring):
+        if isinstance(addresses, str):
             addresses = [addresses]
         else:
             addresses = list(addresses)

--- a/mailprocessing/mail/header.py
+++ b/mailprocessing/mail/header.py
@@ -18,7 +18,7 @@
 # 02110-1301, USA.
 
 import re
-import sys
+
 
 class MailHeader(object):
     def __init__(self, mail, name, text):

--- a/mailprocessing/mail/maildir.py
+++ b/mailprocessing/mail/maildir.py
@@ -90,9 +90,10 @@ class MaildirMail(MailBase):
             self._processor.create_maildir_name() + flagpart)
         try:
             self._processor.rename(self.path, target)
+            self._processor.log("==> Moved: \n(src) {0} -->\n(tgt) {1}".format(self.path, target))
         except IOError as e:
             self._processor.log_io_error(
-                "Could not rename {0} to {1}".format(tmp_target, target),
+                "Could not rename {0} to {1}".format(self.path, target),
                 e)
 
     def parse_mail(self):

--- a/mailprocessing/mail/maildir.py
+++ b/mailprocessing/mail/maildir.py
@@ -20,7 +20,6 @@
 import os
 import shutil
 import subprocess
-import sys
 
 from email import errors as email_errors
 from email import header as email_header
@@ -29,6 +28,7 @@ from email import parser as email_parser
 from mailprocessing.mail.base import MailBase
 from mailprocessing.util import iso_8601_now
 from mailprocessing.util import sha1sum
+
 
 class MaildirMail(MailBase):
     def __init__(self, processor, **kwargs):
@@ -198,7 +198,7 @@ class MaildirMail(MailBase):
                 e)
 
     def _forward(self, delete, addresses, env_sender):
-        if isinstance(addresses, basestring):
+        if isinstance(addresses, str):
             addresses = [addresses]
         else:
             addresses = list(addresses)
@@ -220,11 +220,10 @@ class MaildirMail(MailBase):
             return
 
         p = subprocess.Popen(
-            "{0} {1} -- {2}".format(
-                self._processor.sendmail,
-                flags,
-                " ".join(addresses)
-                ),
+            "{0} {1} -- {2}".format(self._processor.sendmail,
+                                    flags,
+                                    " ".join(addresses)
+                                    ),
             shell=True,
             stdin=subprocess.PIPE)
         shutil.copyfileobj(source_fp, p.stdin)
@@ -259,7 +258,6 @@ class MaildirMail(MailBase):
             return ":2," + parts[1]
         else:
             return ""
-
 
     def _log_processing(self):
         try:

--- a/mailprocessing/mail/target.py
+++ b/mailprocessing/mail/target.py
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301, USA.
 
-import sys
 
 class MailTarget(object):
     _target_headers = ["to", "cc"]

--- a/mailprocessing/processor/generic.py
+++ b/mailprocessing/processor/generic.py
@@ -18,29 +18,23 @@
 # 02110-1301, USA.
 
 import fcntl
-import hashlib
-import locale
 import os
-import random
-import socket
 import sys
 import time
 
 from mailprocessing import signals
 
-from mailprocessing.util import iso_8601_now
 from mailprocessing.util import safe_write
+
 
 class MailProcessor(object):
     def __init__(
             self, rcfile, log_fp, **kwargs):
 
-        defaults = {
-          'log_level': 1,
-          'dry_run': False,
-          'run_once': False,
-          'auto_reload_rcfile': False
-          }
+        defaults = {'log_level': 1,
+                    'dry_run': False,
+                    'run_once': False,
+                    'auto_reload_rcfile': False}
 
         for key in defaults:
             if key not in kwargs:
@@ -78,7 +72,7 @@ class MailProcessor(object):
                 try:
                     fcntl.flock(self._log_fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     lock_acquired = True
-                except OSError as e:
+                except OSError:
                     print("Couldn't acquire lock on log file %s, sleeping "
                           "for 5s" % self._log_fp.name, file=sys.stderr)
                     time.sleep(5)
@@ -187,13 +181,15 @@ class MailProcessor(object):
         """
         Converts path to list form and returns path prepended with the
         processor's path prefix. If its leading component is already the prefix
-        or there is no prefix set, the original path in list form is returned. 
+        or there is no prefix set, the original path in list form is returned.
         """
 
         path = self.path_list(path)
         if len(path) == 0:
             return path
 
+        if sep == '/':
+            return path
         # Special case (mostly relevant for maildirs):
         # Return an empty first component if path and
         # prefix are identical.

--- a/mailprocessing/processor/maildir.py
+++ b/mailprocessing/processor/maildir.py
@@ -18,21 +18,15 @@
 # 02110-1301, USA.
 
 import errno
-import hashlib
-import locale
 import os
 import random
 import socket
-import sys
 import time
-
-
-from mailprocessing.util import iso_8601_now
-from mailprocessing.util import safe_write
 
 from mailprocessing.processor.generic import MailProcessor
 from mailprocessing.mail.dryrun import DryRunMaildir
 from mailprocessing.mail.maildir import MaildirMail
+
 
 class MaildirProcessor(MailProcessor):
     def __init__(self, *args, **kwargs):
@@ -91,7 +85,7 @@ class MaildirProcessor(MailProcessor):
                         for mail_file in os.listdir(subdir_path):
                             mail_path = os.path.join(subdir_path, mail_file)
                             yield self._mail_class(self, maildir=maildir,
-                                                         mail_path=mail_path)
+                                                   mail_path=mail_path)
             if self._run_once:
                 break
             time.sleep(1)
@@ -132,21 +126,20 @@ class MaildirProcessor(MailProcessor):
         self.log("==> Successfully created folder %s" % target)
 
     def create_maildir(self, name, parents=True):
-      """
-      Creates a new maildir.
-      """
-      for d in ['cur', 'new', 'tmp']:
-        try:
-          if parents:
-              os.makedirs(os.path.join(name, d), mode=0o700)
-          else:
-              os.mkdir(os.path.join(name, d), mode=0o700)
-        except OSError as e:
-          if e.errno == errno.EEXIST:
-            pass
-          else:
-            raise
-
+        """
+        Creates a new maildir.
+        """
+        for d in ['cur', 'new', 'tmp']:
+            try:
+                if parents:
+                    os.makedirs(os.path.join(name, d), mode=0o700)
+                else:
+                    os.mkdir(os.path.join(name, d), mode=0o700)
+            except OSError as e:
+                if e.errno == errno.EEXIST:
+                    pass
+                else:
+                    raise
 
     def create_maildir_name(self):
         """Create and return a unique name for a Maildir message."""

--- a/mailprocessing/processor/maildir.py
+++ b/mailprocessing/processor/maildir.py
@@ -167,4 +167,8 @@ class MaildirProcessor(MailProcessor):
             errmsg)
 
     def rename(self, source, target):
-        os.rename(source, target)
+        try:
+            os.rename(source, target)
+        except FileNotFoundError:
+            self.log_error("Error: Moving file from {0} to {1}. Maybe it doesn't exist?".format(
+                source, target))

--- a/mailprocessing/signals.py
+++ b/mailprocessing/signals.py
@@ -23,6 +23,7 @@ import threading
 signal_event = threading.Event()
 signal_received = None
 
+
 def handler(signum, frame):
     global signal_event   # used for interruptable sleep
     if not signum == signal.SIGHUP:
@@ -34,8 +35,10 @@ def handler(signum, frame):
 def hup_received():
     return signal_received == signal.SIGHUP
 
+
 def terminate():
     return (signal_received == signal.SIGINT) or (signal_received == signal.SIGTERM)
+
 
 signal.signal(signal.SIGINT, handler)
 signal.signal(signal.SIGTERM, handler)

--- a/mailprocessing/util.py
+++ b/mailprocessing/util.py
@@ -25,6 +25,7 @@ import time
 
 basestring = str
 
+
 def offset_to_timezone(offset):
     if offset <= 0:
         sign = "+"
@@ -46,19 +47,19 @@ def iso_8601_now():
 
 
 def batch_list(to_batch, batchsize=1000):
-  """
-  Divide large lists. Returns a list of lists with batchsize or fewer items.
-  """
+    """
+    Divide large lists. Returns a list of lists with batchsize or fewer items.
+    """
 
-  cur = 0
-  batches = []
+    cur = 0
+    batches = []
 
-  while cur <= len(to_batch):
-    increment = min(len(to_batch) - (cur - 1), batchsize)
-    batches.append(to_batch[cur:cur + increment])
-    cur += increment
+    while cur <= len(to_batch):
+        increment = min(len(to_batch) - (cur - 1), batchsize)
+        batches.append(to_batch[cur:cur + increment])
+        cur += increment
 
-  return batches
+    return batches
 
 
 def sha1sum(fp):

--- a/mailprocessing/version.py
+++ b/mailprocessing/version.py
@@ -20,4 +20,4 @@
 # Change the version below to change the mailprocessing/imapproc version. This
 # controls the python module's version as well.
 
-PKG_VERSION = "1.2.8"
+PKG_VERSION = "1.2.7"

--- a/mailprocessing/version.py
+++ b/mailprocessing/version.py
@@ -20,4 +20,4 @@
 # Change the version below to change the mailprocessing/imapproc version. This
 # controls the python module's version as well.
 
-PKG_VERSION = "1.2.7"
+PKG_VERSION = "1.2.8"

--- a/run-testsuite
+++ b/run-testsuite
@@ -13,25 +13,21 @@ from os.path import join as joinpath
 class TestFixture(unittest.TestCase):
     _maildir_dir = "test.maildir.%d" % os.getpid()
     _testdata_dir = "test.testdata.%d" % os.getpid()
-    _testmail_data_a = [
-        "From: Sender <sender@example.com>\n",
-        "To: Recipient <recipient@example.com>\n",
-        "Cc: Carbon Copy <carbon.copy@example.com>\n",
-        "Subject: A subject with =?utf8?b?csOkdnNtw7ZyZ8Olcw==?=\n",
-        "Delivered-To: Alpha\n",
-        "X-BeenThere: Bravo\n",
-        "X-Mailing-List: Charlie\n",
-        "Mailing-List: Delta\n",
-        "\n",
-        "Body. R\xc3\xa4vsm\xc3\xb6rg\xc3\xa5s.\n",
-        ]
-    _testmail_data_bad_header = [
-        "From: Sender <sender@example.com>\n",
-        "To: Recipient <recipient@example.com>\n",
-        "Subject: =?ISO-2022-JP?B?gYqBiQ=?=\n",
-        "\n",
-        "Body.\n",
-        ]
+    _testmail_data_a = ["From: Sender <sender@example.com>\n",
+                        "To: Recipient <recipient@example.com>\n",
+                        "Cc: Carbon Copy <carbon.copy@example.com>\n",
+                        "Subject: A subject with =?utf8?b?csOkdnNtw7ZyZ8Olcw==?=\n",
+                        "Delivered-To: Alpha\n",
+                        "X-BeenThere: Bravo\n",
+                        "X-Mailing-List: Charlie\n",
+                        "Mailing-List: Delta\n",
+                        "\n",
+                        "Body. R\xc3\xa4vsm\xc3\xb6rg\xc3\xa5s.\n"]
+    _testmail_data_bad_header = ["From: Sender <sender@example.com>\n",
+                                 "To: Recipient <recipient@example.com>\n",
+                                 "Subject: =?ISO-2022-JP?B?gYqBiQ=?=\n",
+                                 "\n",
+                                 "Body.\n"]
 
     def setUp(self):
         shutil.rmtree(self._testdata_dir, True)
@@ -60,25 +56,20 @@ class TestFixture(unittest.TestCase):
             extra_argv = ["-b", self._maildir_dir]
         else:
             extra_argv = ["-b", maildir_base]
-        argv = [
-            "./%s" % self._maildirproc_name,
-            "--once",
-            "-l", "/dev/null",
-            "-r", "-",
-            ] + extra_argv
+        argv = ["./%s" % self._maildirproc_name,
+                "--once",
+                "-l", "/dev/null",
+                "-r", "-"] + extra_argv
         for maildir in maildirs:
             argv.extend(["-m", maildir])
         sh_cmd = "-c 'a=%s/delivered; echo $1 >$a; cat >>$a'" % (
             self._testdata_dir)
-        p = subprocess.Popen(
-            argv,
-            stdin=subprocess.PIPE,
-            env={
-                "SENDMAIL": "/bin/sh",
-                "SENDMAILFLAGS": sh_cmd,
-                },
-            )
-        p.communicate(textwrap.dedent(rc))
+        p = subprocess.Popen(argv,
+                             stdin=subprocess.PIPE,
+                             env={"SENDMAIL": "/bin/sh",
+                                  "SENDMAILFLAGS": sh_cmd})
+        dedented_rc = textwrap.dedent(rc)
+        p.communicate(bytes(dedented_rc, encoding="utf8"))
         p.wait()
         assert(p.returncode == 0)
 
@@ -400,13 +391,11 @@ class TestSuite(TestFixture):
              "x-beenthere", "x-mailing-list", "mailing-list"])
         self.create("a", "incoming/new/a")
         self.run_mdp(rc, ["incoming"])
-        self.verify_result({
-            "incoming/new": 1,
-            "delivered-to/new": 1,
-            "x-beenthere/new": 1,
-            "x-mailing-list/new": 1,
-            "mailing-list/new": 1,
-            })
+        self.verify_result({"incoming/new": 1,
+                            "delivered-to/new": 1,
+                            "x-beenthere/new": 1,
+                            "x-mailing-list/new": 1,
+                            "mailing-list/new": 1})
 
 
 class Python2TestSuite(TestSuite):
@@ -419,6 +408,7 @@ class Python3TestSuite(TestSuite):
         TestSuite.__init__(self, method_name, False, "maildirproc")
 
 ######################################################################
+
 
 test_runner = unittest.TextTestRunner()
 test_loader = unittest.defaultTestLoader


### PR DESCRIPTION
First of all, thank you for this awesome package. I use it everyday to clean up my mail. 😀

The only actual code change is in generic.path_ensure_prefix, line 191, 192 added.
When using `processor.separator = '/'` in the rc file, this change prevents path concatenations like `mail-base/./FolderA`.

Other changes:
- Remove unused imports and unused variables
- Replace `basestring` with `str` (python3)
- whitespace and indentation changes to pass flake8 linting

Tested it on my local setup and works OK. May need more testing.
Let me know if I can make any updates.

Best,
Gaurav