### PR TITLE
Allow to mark new mail as read

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -213,8 +213,8 @@
 <dt>is_flagged()</dt>
 <dd><p>Returns True if the message has been flagged by the user, False otherwise.</p>
 </dd>
-<dt>mark_read()<dt>
-<dd><p>Marks the mail as read.</p>
+<dt>mark_seen()<dt>
+<dd><p>Marks the mail as having been seen by the user.</p>
 </dd>
 <dt>move(<em>maildir</em>, <em>create=False</em>)</dt>
 <dd><p>Move the mail to <em>maildir</em> (a string). <em>maildir</em> <strong>must</strong> be on the same file system as the mail, otherwise nothing will happen and an error will be logged. For MaildirProcessor, a relative <em>maildir</em> path, will be considered relative to the maildir base directory. If the optional <em>create</em> keyword argument is set to True, the folder (and its parent folders) will be created if it does not exist. By default non-existent folders are not created.</p>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -214,7 +214,8 @@
 <dd><p>Returns True if the message has been flagged by the user, False otherwise.</p>
 </dd>
 <dt>mark_read()<dt>
-<dd>Marks the e-mail as read.</dd>
+<dd><p>Marks the mail as read.</p>
+</dd>
 <dt>move(<em>maildir</em>, <em>create=False</em>)</dt>
 <dd><p>Move the mail to <em>maildir</em> (a string). <em>maildir</em> <strong>must</strong> be on the same file system as the mail, otherwise nothing will happen and an error will be logged. For MaildirProcessor, a relative <em>maildir</em> path, will be considered relative to the maildir base directory. If the optional <em>create</em> keyword argument is set to True, the folder (and its parent folders) will be created if it does not exist. By default non-existent folders are not created.</p>
 </dd>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -213,6 +213,8 @@
 <dt>is_flagged()</dt>
 <dd><p>Returns True if the message has been flagged by the user, False otherwise.</p>
 </dd>
+<dt>mark_read()<dt>
+<dd>Marks the e-mail as read.</dd>
 <dt>move(<em>maildir</em>, <em>create=False</em>)</dt>
 <dd><p>Move the mail to <em>maildir</em> (a string). <em>maildir</em> <strong>must</strong> be on the same file system as the mail, otherwise nothing will happen and an error will be logged. For MaildirProcessor, a relative <em>maildir</em> path, will be considered relative to the maildir base directory. If the optional <em>create</em> keyword argument is set to True, the folder (and its parent folders) will be created if it does not exist. By default non-existent folders are not created.</p>
 </dd>

--- a/mailprocessing/mail/base.py
+++ b/mailprocessing/mail/base.py
@@ -178,6 +178,18 @@ class MailBase(object):
                    "MailBase subclass.")
         raise NotImplementedError(message)
 
+    def mark_seen(self):
+        """
+        Mark a message as having been read.
+
+        This message is marked as having been read; the operation should be
+        idempotent.
+        """
+
+        message = ("You need to implement a mark_seen() method in your "
+                   "MailBase subclass.")
+        raise NotImplementedError(message)
+
     def is_seen(self):
         """
         Check whether a message has been read.

--- a/mailprocessing/mail/dryrun.py
+++ b/mailprocessing/mail/dryrun.py
@@ -39,6 +39,9 @@ class DryRunImap(ImapMail):
     def forward_copy(self, addresses, env_sender=None):
         self._forward(False, addresses, env_sender)
 
+    def mark_seen(self):
+        self._processor.log("==> Flag as read {0}".format(self.path))
+
     def move(self, maildir, **kwargs):
         maildir = self.processor.list_path(maildir,
                                            sep=self.processor.separator)
@@ -80,6 +83,9 @@ class DryRunMaildir(MaildirMail):
 
     def forward_copy(self, addresses, env_sender=None):
         self._forward(False, addresses, env_sender)
+
+    def mark_seen(self):
+        self._processor.log("==> Flag as read {0}".format(self.path))
 
     def move(self, maildir, **kwargs):
         maildir = self.processor.list_path(maildir,

--- a/mailprocessing/mail/imap.py
+++ b/mailprocessing/mail/imap.py
@@ -242,6 +242,21 @@ class ImapMail(MailBase):
 
         return seen_status
 
+    def mark_seen(self):
+        """
+        Sets the messages's '\Seen' flag.
+        """
+        if '\\Seen' in self.message_flags:
+            return
+        try:
+            self._processor.log("==> Marking %s as seen" % self.uid)
+            self._processor.imap.uid('store', self.uid, '+FLAGS', r'(\Seen)')
+        except self._processor.imap.error as e:
+            self._processor.log_imap_error(
+                "Error: Could not mark message {0} as seen: {1}".format(
+                    self.uid, e))
+        self.message_flags.append('\\Seen')
+
     def move(self, folder, create=False):
         """
         Moves the message to folder. Optionally that folder can be created if


### PR DESCRIPTION
This is a rewrite of #1 since that's outdated and has significant merge conflicts at this point.  I've taken a couple commits (for docs) from there, though, to preserve the lineage and credit the original author.

Note that this is based on #9 and should be reviewed after that one merges (or closed for not wanting to merge in, in which case I'll rebase this and drop the relevant tests).

Some questions, before the proper code review:
- For maildir, just renaming the file on disk is fine, correct? No need to regenerate a maildir name or anything?
- For IMAP, I don't need to muck with the cache?