### PR TITLE
Fix errors and warnings flagged by pyflakes

### DIFF
--- a/docs/pandoc/delink.py
+++ b/docs/pandoc/delink.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
-import sys
-
 """
 Pandoc filter for stripping links down to just their titles.
 """
 
-from pandocfilters import toJSONFilter, Emph, Para
+from pandocfilters import toJSONFilter
 
 def striplinks(key, value, format, meta):
   if key == 'Link':

--- a/mailprocessing/mail/maildir.py
+++ b/mailprocessing/mail/maildir.py
@@ -143,7 +143,7 @@ class MaildirMail(MailBase):
                 self._processor.create_folder(maildir, **kwargs)
             except OSError as e:
                 self._processor.fatal_error("Couldn't create maildir "
-                                            "%s: %s" % (target, e))
+                                            "%s: %s" % (maildir, e))
         try:
             source_fp = open(self.path, "rb")
         except IOError as e:

--- a/mailprocessing/util.py
+++ b/mailprocessing/util.py
@@ -86,7 +86,7 @@ def write_pidfile(pidfile):
         try:
             fcntl.flock(pidfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
             lock_acquired = True
-        except OSError as e:
+        except OSError:
             print("Couldn't acquire lock on pid file %s, sleeping for 5s" % pidfile.name, file=sys.stderr)
         time.sleep(5)
 


### PR DESCRIPTION
The most important one is the undefined `target` variable in
`mailprocessing.mail.MaildirMail._copy`.